### PR TITLE
Added github workflow for multi arch docker images

### DIFF
--- a/.github/workflows/docker-multi-arch.yml
+++ b/.github/workflows/docker-multi-arch.yml
@@ -1,0 +1,65 @@
+name: Publish multi-arch Docker images
+
+on:
+    push:
+        branches:
+            - main
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                base: [ 'debian:bullseye-20220125-slim', 'debian:buster-20220125-slim', 'ubuntu:focal-20220105' ]
+                sourceforge: [ 'Y', 'N' ]
+                exclude:
+                    - base: 'ubuntu:focal-20220105'
+                      sourceforge: 'Y'
+                
+        steps:
+        -
+            name: Checkout
+            uses: actions/checkout@v2
+        -
+            name: Set Release Tag
+            run: |
+                date=$(date '+%Y-%m-%d')
+                sourceforge=""
+                if [ "${{ matrix.sourceforge }}" = "Y" ]; \
+                then sourceforge="sourceforge-"; fi
+                base="$(cut -d ':' -f2 <<< '${{ matrix.base }}')"
+                base="$(cut -d '-' -f1 <<< ${base})"
+                tags="${{secrets.DOCKER_USERNAME}}/squeezelite:${sourceforge}${base},${{secrets.DOCKER_USERNAME}}/squeezelite:${sourceforge}${base}-${date}"
+                if [ "${base}" = "bullseye" ] && [ "${{ matrix.sourceforge }}" = "Y" ]; \
+                then echo "RELEASE_TAGS=${tags},${{secrets.DOCKER_USERNAME}}/squeezelite:latest"; \
+                elif [ "${base}" = "buster" ] && [ "${{ matrix.sourceforge }}" = "N" ]; \
+                then echo "RELEASE_TAGS=${tags},${{secrets.DOCKER_USERNAME}}/squeezelite:stable"; \
+                else echo "RELEASE_TAGS=${tags}"; fi \
+                >> $GITHUB_ENV
+        -
+            name: Set up QEMU
+            uses: docker/setup-qemu-action@v1
+            with:
+                platforms: all
+        -
+            name: Set up Docker Buildx
+            id: buildx
+            uses: docker/setup-buildx-action@v1
+        -
+            name: Login to DockerHub
+            uses: docker/login-action@v1
+            with:
+                username: ${{ secrets.DOCKER_USERNAME }}
+                password: ${{ secrets.DOCKER_PASSWORD }}
+        -
+            name: Build and push
+            uses: docker/build-push-action@v2
+            with:
+                context: .
+                build-args: |
+                    BASE_IMAGE=${{ matrix.base }}
+                    DOWNLOAD_FROM_SOURCEFORGE=${{ matrix.sourceforge }}
+                platforms: linux/amd64,linux/arm/v7,linux/arm64/v8
+                push: true
+                tags: ${{ env.RELEASE_TAGS }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 Now with support for upsampling and presets for maximum convenience.
 
+## Available Archs on Docker Hub
+- linux/arm/v7
+- linux/amd64
+- linux/arm64/v8
+
 ## Reference
 
 First and foremost, the reference to the awesome project:


### PR DESCRIPTION
Workflow creates docker images for the following os/arch:

- linux/arm/v6
- linux/arm/v7
- linux/amd64
- linux/arm64/v8

Workflow requires set repository secrets for docker hub credentials:

- DOCKER_USERNAME
- DOCKER_PASSWORD

The workflow creates and pushes an image with tag "latest" on every push to the main branch. Pushing a tag creates an image with the same tag.