### PR TITLE
builder for stable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,3 @@
-MultiArch build:
+#!/bin/sh
 
 docker build --push --platform linux/arm/v7,linux/amd64 --tag giof71/squeezelite:stable .


### PR DESCRIPTION
Main currently must be same as stable.
Base on debian:buster with binaries from repos