### PR TITLE
[Maintenance] Add support for lunar #198

### DIFF
--- a/.github/workflows/docker-multi-arch-regular.yml
+++ b/.github/workflows/docker-multi-arch-regular.yml
@@ -52,6 +52,7 @@ jobs:
           sl_versions[bookworm]=1.9.9
           sl_versions[bullseye]=1.9.8
           sl_versions[buster]=1.8
+          sl_versions[lunar]=1.9.9
           sl_versions[kinetic]=1.9.9
           sl_versions[jammy]=1.9.9
 

--- a/.github/workflows/docker-multi-arch-sourceforge.yml
+++ b/.github/workflows/docker-multi-arch-sourceforge.yml
@@ -38,6 +38,7 @@ jobs:
           base_image_from_matrix[bookworm]=debian:bookworm-slim
           base_image_from_matrix[buster]=debian:buster-slim
           base_image_from_matrix[bullseye]=debian:bullseye-slim
+          base_image_from_matrix[lunar]=ubuntu:lunar
           base_image_from_matrix[kinetic]=ubuntu:kinetic
           base_image_from_matrix[jammy]=ubuntu:jammy
 

--- a/app/conf/01-apt-proxy
+++ b/app/conf/01-apt-proxy
@@ -1,1 +1,2 @@
 Acquire::http::proxy "http://apt.homelab.local:3142";
+Acquire::https::proxy "DIRECT";

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,7 @@ base_images[bionic]=ubuntu:bionic
 base_images[focal]=ubuntu:focal
 base_images[jammy]=ubuntu:jammy
 base_images[kinetic]=ubuntu:kinetic
+base_images[lunar]=ubuntu:lunar
 base_images[rolling]=ubuntu:rolling
 
 base_images[debian:bookworm]=debian:bookworm-slim
@@ -31,6 +32,7 @@ base_images[ubuntu:bionic]=ubuntu:bionic
 base_images[ubuntu:focal]=ubuntu:focal
 base_images[ubuntu:jammy]=ubuntu:jammy
 base_images[ubuntu:kinetic]=ubuntu:kinetic
+base_images[ubuntu:lunar]=ubuntu:lunar
 base_images[ubuntu:rolling]=ubuntu:rolling
 
 DEFAULT_BASE_IMAGE=bullseye


### PR DESCRIPTION
We can build 'lunar' based images using build.sh
No ubuntu builds are created via the github workflows.
